### PR TITLE
Add autostart script for mac

### DIFF
--- a/res/macos_autostart.sh
+++ b/res/macos_autostart.sh
@@ -1,16 +1,11 @@
 #!/usr/bin/env bash
 
-if [[ $EUID -ne 0 ]]; then
-	echo "This script must be run as root"
-	exit 1
-fi
-
 if [[ ":$PATH:" != *":$HOME/.cargo/bin:"* ]]; then
 	echo "Cargo is not in your path, please fix this and try again"
 	exit 1
 fi
 
-PLIST_PATH="/Library/LaunchAgents/timeplot.plist"
+PLIST_PATH="$HOME/Library/LaunchAgents/timeplot.plist"
 TIMEPLOT_PATH="$HOME/.cargo/bin/timeplot"
 
 cat >"$PLIST_PATH" <<EOF

--- a/res/macos_autostart.sh
+++ b/res/macos_autostart.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+if [[ $EUID -ne 0 ]]; then
+	echo "This script must be run as root"
+	exit 1
+fi
+
+if [[ ":$PATH:" != *":$HOME/.cargo/bin:"* ]]; then
+	echo "Cargo is not in your path, please fix this and try again"
+	exit 1
+fi
+
+PLIST_PATH="/Library/LaunchAgents/timeplot.plist"
+TIMEPLOT_PATH="$HOME/.cargo/bin/timeplot"
+
+cat >"$PLIST_PATH" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>timeplot</string>
+    <key>OnDemand</key>
+    <false/>
+    <key>Program</key>
+    <string>${TIMEPLOT_PATH}</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <false/>
+    <key>LaunchOnlyOnce</key>        
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/tmp/startup.stdout</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/startup.stderr</string>
+</dict>
+</plist>
+EOF
+
+launchctl load -w "$PLIST_PATH"
+
+echo "Open Security & Privacy, click Accessibility, check Timeplot"

--- a/res/timeplot.plist
+++ b/res/timeplot.plist
@@ -1,14 +1,3 @@
-#!/usr/bin/env bash
-
-if [[ ":$PATH:" != *":$HOME/.cargo/bin:"* ]]; then
-	echo "Cargo is not in your path, please fix this and try again"
-	exit 1
-fi
-
-PLIST_PATH="$HOME/Library/LaunchAgents/timeplot.plist"
-TIMEPLOT_PATH="$HOME/.cargo/bin/timeplot"
-
-cat >"$PLIST_PATH" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -18,7 +7,7 @@ cat >"$PLIST_PATH" <<EOF
     <key>OnDemand</key>
     <false/>
     <key>Program</key>
-    <string>${TIMEPLOT_PATH}</string>
+    <string>%PATH%</string>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
@@ -31,8 +20,3 @@ cat >"$PLIST_PATH" <<EOF
     <string>/tmp/startup.stderr</string>
 </dict>
 </plist>
-EOF
-
-launchctl load -w "$PLIST_PATH"
-
-echo "Open Security & Privacy, click Accessibility, check Timeplot"

--- a/src/main.rs
+++ b/src/main.rs
@@ -480,7 +480,7 @@ fn do_save_current(dirs: &ProjectDirs, image_dir: &PathBuf, conf: &Config) {
 }
 
 fn exe_name() -> Option<String> {
-	std::env::current_exe()
+	env::current_exe()
 		.ok()
 		.map(PathBuf::into_os_string)
 		.and_then(|exe| exe.into_string().ok())

--- a/src/main.rs
+++ b/src/main.rs
@@ -484,7 +484,7 @@ fn add_to_autostart() {
 	let executable_name = env::current_exe().expect("failed to get current executable name");
 	let executable_name = executable_name.to_str().unwrap_or_else(|| {
 		panic!(
-			"failet to read executable name '{:?}' to string",
+			"failed to read executable name '{:?}' to string",
 			executable_name
 		)
 	});
@@ -496,7 +496,33 @@ fn add_to_autostart() {
 		.join(".config/autostart/TimePlot.desktop");
 	ensure_file(&file_path, &xdg_desktop);
 }
-#[cfg(not(target_os = "linux"))]
+
+#[cfg(target_os = "macos")]
+fn add_to_autostart() {
+	let executable_name = env::current_exe().expect("failed to get current executable name");
+	let executable_name = executable_name.to_str().unwrap_or_else(|| {
+		panic!(
+			"failed to read executable name '{:?}' to string",
+			executable_name
+		)
+	});
+	let plist = include_str!("../res/timeplot.plist");
+	let plist = plist.replace("%PATH%", executable_name);
+	let file_path = UserDirs::new()
+		.expect("failed to calculate user dirs")
+		.home_dir()
+		.join("Library/LaunchAgents/timeplot.plist");
+	ensure_file(&file_path, &plist);
+
+	Command::new("launchctl")
+		.arg("load")
+		.arg("-w")
+		.arg(file_path)
+		.output()
+		.expect("failed to execute");
+}
+
+#[cfg(target_os = "windows")]
 fn add_to_autostart() {}
 
 #[cfg(target_os = "windows")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -479,17 +479,20 @@ fn do_save_current(dirs: &ProjectDirs, image_dir: &PathBuf, conf: &Config) {
 	});
 }
 
+fn exe_name() -> Option<String> {
+	std::env::current_exe()
+		.ok()
+		.map(PathBuf::into_os_string)
+		.and_then(|exe| exe.into_string().ok())
+}
+
 #[cfg(target_os = "linux")]
 fn add_to_autostart() {
-	let executable_name = env::current_exe().expect("failed to get current executable name");
-	let executable_name = executable_name.to_str().unwrap_or_else(|| {
-		panic!(
-			"failed to read executable name '{:?}' to string",
-			executable_name
-		)
-	});
+	let executable_name =
+		exe_name().unwrap_or_else(|| panic!("failed to read the executable name to string",));
+
 	let xdg_desktop = include_str!("../res/linux_autostart.desktop");
-	let xdg_desktop = xdg_desktop.replace("%PATH%", executable_name);
+	let xdg_desktop = xdg_desktop.replace("%PATH%", executable_name.as_str());
 	let file_path = UserDirs::new()
 		.expect("failed to calculate user dirs")
 		.home_dir()
@@ -499,15 +502,11 @@ fn add_to_autostart() {
 
 #[cfg(target_os = "macos")]
 fn add_to_autostart() {
-	let executable_name = env::current_exe().expect("failed to get current executable name");
-	let executable_name = executable_name.to_str().unwrap_or_else(|| {
-		panic!(
-			"failed to read executable name '{:?}' to string",
-			executable_name
-		)
-	});
+	let executable_name =
+		exe_name().unwrap_or_else(|| panic!("failed to read the executable name to string",));
+
 	let plist = include_str!("../res/timeplot.plist");
-	let plist = plist.replace("%PATH%", executable_name);
+	let plist = plist.replace("%PATH%", executable_name.as_str());
 	let file_path = UserDirs::new()
 		.expect("failed to calculate user dirs")
 		.home_dir()
@@ -522,7 +521,7 @@ fn add_to_autostart() {
 		.expect("failed to execute");
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(all(not(target_os = "linux"), not(target_os = "macos")))]
 fn add_to_autostart() {}
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
Must be executed as root to write to LaunchAgents and runs as the $USER.
Starts `timeplot` at login

Didn't bother with spctl/Gatekeeper stuff to trust the application, this needs to be manually done.

I have tested locally and its working without issues.